### PR TITLE
lens.ipkg: add missing modules

### DIFF
--- a/lens.ipkg
+++ b/lens.ipkg
@@ -1,19 +1,23 @@
 package lens
 
-modules = Control.Lens.Types
+modules = Control.Lens
+        , Control.Lens.At
         , Control.Lens.Const
-        , Data.Contravariant
+        , Control.Lens.Examples
         , Control.Lens.First
         , Control.Lens.Getter
-        , Control.Lens.Setter
-        , Control.Lens.Prism
-        , Control.Lens.Tuple
         , Control.Lens.Iso
+        , Control.Lens.Market
         , Control.Lens.Maths
-        , Control.Lens.Examples
-        , Control.Lens
+        , Control.Lens.Prism
+        , Control.Lens.Review
+        , Control.Lens.Setter
+        , Control.Lens.Tuple
+        , Control.Lens.Types
+        , Data.Contravariant
         , Data.Profunctor
-        , Data.Profunctor.Class
         , Data.Profunctor.Choice
+        , Data.Profunctor.Class
+        , Data.Tagged
 
 opts = "-p bifunctors"


### PR DESCRIPTION
looks like some stuff got missed in c7dc944d02087373b072e3f4c790a690113094ea.
This caused https://github.com/HuwCampbell/optparse-idris/issues/5.
